### PR TITLE
Repair "save game limit" and "bonus liquid" options.

### DIFF
--- a/Trap Quest.inform/Inform/Extensions/Miscellaneous Backend/Game Settings.i7x
+++ b/Trap Quest.inform/Inform/Extensions/Miscellaneous Backend/Game Settings.i7x
@@ -884,7 +884,7 @@ Check game save counter:
 		say "You don't have a permission to save the game. Nintendolls, with love.";
 		rule fails.
 The increase game save counter rules are a rulebook. The increase game save counter rules have default success.
-To increase game save counter: 
+Increase game save counter: 
 	if save game limit is 1 and (the player is not in Capsule) and (the player is not in Hotel36) and debugmode is 0:
 		increase save game counter by 1; 
 		say "You now have [remaining game saves] saves remaining.".

--- a/Trap Quest.inform/Inform/Extensions/Rooms/Deploying.i7x
+++ b/Trap Quest.inform/Inform/Extensions/Rooms/Deploying.i7x
@@ -61,7 +61,7 @@ To deploy tank in (G - a room):
 		now a random off-stage paddle trap is in G;
 		if debugmode is 1, say "The tank is trapped with a paddle trap.[paragraph break]";
 	let T be a random tank in Holding Pen;
-	now the doses of T is a random number from 3 to 8;
+	now the doses of T is a random number from 2 + bonus liquid to 8;
 	now T is in G.
 
 [!<DeployBucketInRoom>+
@@ -74,7 +74,7 @@ To deploy bucket in (G - a room):
 	if the number of on-stage iron-maidens is 0:
 		now a random off-stage iron-maiden is in G;
 	let T be a random bucket in Holding Pen;
-	now the doses of T is a random number from 3 to 8;
+	now the doses of T is a random number from 2 + bonus liquid to 8;
 	now T is in G.
 
 [!<DeployMinibarInRoom>+


### PR DESCRIPTION
Hello, Aika!

1. Here are the corrections of the two options that I once did. They do not work for a long time (the "save limit" was broken between the two fixes in version 5.4, and the "bonus liquid" appears to be in version 6.1 or 6.2), and since no one noticed it, I think, that they are not required at all. Most likely they just need to be removed, but I decided to fix them.

2. In the public version there are not some files that I would like to edit, so I have a small "feature request" - add the command to debug mode (something like "no more cheats") that disabled the debugging mode and the test commands ( "gonear", "purloin", "showme", "debug", etc.) in the current game session forever.

Thanks you for great game!